### PR TITLE
Fix Buy with Shop button disabled by Easify Product Options

### DIFF
--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -215,6 +215,32 @@ product-info {
   letter-spacing: 0.1rem;
 }
 
+/*
+  Easify Product Options ("tpo") disables the native "Buy with Shop" /
+  accelerated checkout button via `pointer-events: none` on every product it's
+  active on — including products that have no option set — which leaves the
+  button unclickable. Re-enable it only where there is NO Easify option set;
+  products that DO have options keep it disabled, because Shop Pay's express
+  checkout can't carry custom option line-item properties. Detection mirrors
+  Easify's own `.tpo_has-option-set` marker. `pointer-events` is inherited, so
+  restoring it on the accelerated-checkout element also restores the nested
+  wallet button and the "More payment options" link.
+*/
+.product__info-wrapper:not(:has(.tpo_has-option-set)) .shopify-payment-button shopify-accelerated-checkout {
+  pointer-events: auto !important;
+}
+
+/*
+  On Easify-active products (an option set is present), Shop Pay's express
+  checkout would bypass the cart and drop the custom option line-item
+  properties, so it must not be usable. Easify only sets `pointer-events: none`,
+  which leaves a visible but dead button — hide the whole dynamic checkout block
+  instead so customers use "Add to cart" -> cart, which captures the options.
+*/
+.product__info-wrapper:has(.tpo_has-option-set) .shopify-payment-button {
+  display: none !important;
+}
+
 /* Product info */
 
 .product__info-container > * + * {


### PR DESCRIPTION
Easify Product Options applies pointer-events:none to the native accelerated checkout (shopify-accelerated-checkout) on every product it's active on — including products with no option set — leaving a visible but unclickable Buy with Shop button.

- Re-enable the button only on products without an Easify option set (mirrors Easify's own .tpo_has-option-set detection).
- On products that do have options, hide the dynamic checkout block entirely so customers use Add to cart -> cart, which captures the custom option line-item properties that Shop Pay express would drop.

### PR Summary: 

<!-- Please include a short description (using non-technical terms, 1-2 sentences) about the changes you are introducing, what problem is being fixed and/or describe the benefit to merchants. This content will be used in our release notes for Dawn on [themes.shopify.com](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes). -->


### Why are these changes introduced?

Fixes #0.

### What approach did you take?

### Other considerations

### Decision log

| # | Decision | Alternatives | Rationale | Downsides |
|---|---|---|---|---|
| 1 |   |   |   |   |


### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->


### Testing steps/scenarios
<!-- List all the testing tasks that applies to your fix to help peers review your work. -->
- [ ] Step 1

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](url)
- [Editor](url)

### Checklist
- [ ] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [ ] Requested review from UX (Only for changes that are affecting the experience or perceivable visual details)
- [ ] Created a ticket for the [help.shopify.com](https://help.shopify.com) documentation team about updates to theme settings. (Internal-only task)
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
